### PR TITLE
Use `bullseye` instead of `bookworm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bullseye-slim
 
 # Env variables
 ARG DOCKER_VERSION


### PR DESCRIPTION
Unfortunately, some third-party packages are not supported on bookworm
yet.